### PR TITLE
DEVX-16 Prompt change to distinguish between two similar API keys.

### DIFF
--- a/postman/Setup.ps1
+++ b/postman/Setup.ps1
@@ -3,7 +3,7 @@ if (-not [string]::IsNullOrEmpty($env:POSTMAN_API_KEY)) {
     $postmanApiKey = $env:POSTMAN_API_KEY;
 } 
 else {
-    $secureapiKey = Read-Host "Please enter your Postman API Key (the one from your Postman account)" -AsSecureString;
+    $secureapiKey = Read-Host "Please enter your Postman API Key (the one from your Postman account settings, e.g. PMAK-xxxxxxxxxxxxxxxxxxxxxxxx-XXXX)" -AsSecureString;
     $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($secureapiKey);
     $postmanApiKey = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR);
 }


### PR DESCRIPTION
Added a clarification to the Setup prompt in order to help users distinguish between the two similarly named API keys.